### PR TITLE
Fix path to `DOCUMENT_SERVER_RESULTS`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ it using [build_tools](https://github.com/ONLYOFFICE/build_tools)
 ## ubuntu 18.04
 
 ```bash
-DOCUMENT_SERVER_RESULTS="~/sources/build_tools/out"
+DOCUMENT_SERVER_RESULTS="$HOME/sources/build_tools/out"
 docker build --tag documentserver Ubuntu18.04
 docker run -itd -p 80:80 -v ${DOCUMENT_SERVER_RESULTS}:/out documentserver
 ```


### PR DESCRIPTION
Replace `~` to full path to home directory

Without it 
`docker run -itd -p 80:80 -v ${DOCUMENT_SERVER_RESULTS}:/out documentserver` could not parse correctly path